### PR TITLE
I've added a `docker-compose.yml` file (renamed to `docker.yml` as yo…

### DIFF
--- a/docker.yml
+++ b/docker.yml
@@ -1,0 +1,41 @@
+version: '3.8'
+
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 30s
+      timeout: 30s
+      retries: 3
+
+  reciveapi:
+    build:
+      context: .
+      dockerfile: ReciveAPI/Dockerfile
+    container_name: reciveapi
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - RabbitMQ__HostName=rabbitmq
+
+  backgroundworker:
+    build:
+      context: .
+      dockerfile: BackgroundProcessWorker/Dockerfile
+    container_name: backgroundworker
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - RabbitMQ__HostName=rabbitmq


### PR DESCRIPTION
…u requested) to orchestrate the services for local development.

This file defines three services:
- `reciveapi`: The main API for receiving requests.
- `backgroundworker`: A worker service for background processing.
- `rabbitmq`: A message broker for communication between the API and the worker.

This allows you to spin up the entire application stack with a single `docker-compose up` command.